### PR TITLE
Zip distributive archives without full paths, only executable file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,7 @@ cache:
 # build commands. Rust will automatically be placed in the PATH environment variable.
 build_script:
   - cargo build --all --verbose --release
-  - 7z a emerald-%channel%-%target%-%VERSION%.zip target/release/emerald.exe
+  - 7z a emerald-%channel%-%target%-%VERSION%.zip ./target/release/emerald.exe
 # Uses 'cargo test' to run tests and build. Alternatively, the project may call compiled programs
 # directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 VERSION_BASE=$(janus version -format='v%M.%m.x')
 CLI_ARCHIVE_NAME="emerald-cli-$TRAVIS_OS_NAME-$APP_VERSION"
-zip "$CLI_ARCHIVE_NAME.zip" target/release/emerald
+zip -j "$CLI_ARCHIVE_NAME.zip" target/release/emerald
 tar -zcf "$CLI_ARCHIVE_NAME.tar.gz" target/release/emerald
 echo "Deploy to http://builds.etcdevteam.com/emerald-cli/$VERSION_BASE/"
 


### PR DESCRIPTION
We need store only `emerald.exe` file into zip, without `target/release/` directory structure